### PR TITLE
Shell cleanup

### DIFF
--- a/federlang/comparison/build.sh
+++ b/federlang/comparison/build.sh
@@ -1,1 +1,1 @@
-./jfederc -I base -D comparison/build -O comparison comparison/comparison.fd $@
+./jfederc -I base -D comparison/build -O comparison comparison/comparison.fd "$@"

--- a/federlang/failtests/test.sh
+++ b/federlang/failtests/test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Copyright (C) 2018 Fionn Langhans <fionn.langhans@gmail.com>
 
-FDC_OPTIONS=$@
+FDC_OPTIONS=("$@")
 
 if ! [ -d "failtests" ] ; then
 	echo "Current directory has to be 'federlang'"
@@ -14,7 +14,7 @@ if ! ( [ -e "failtests/error.fd" ] && [ -e "failtests/private_fc.fd" ] && [ -e "
 fi
 
 function feder_failtest_compile {
-	./jfederc -I base -D failtests/build $@ $FDC_OPTIONS 2>/dev/null
+	./jfederc -I base -D failtests/build "$@" "${FDC_OPTIONS[@]}" 2>/dev/null
 	if [ $? == 0 ] ; then
 		echo "Test $1 should have failed"
 	fi

--- a/federlang/tests/test.sh
+++ b/federlang/tests/test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Copyright (C) 2018 Fionn Langhans
 
-FDC_OPTIONS=$@
+FDC_OPTIONS=("$@")
 
 if ! [ -d "tests" ] ; then
 	echo "Current directory has to be 'federlang'"
@@ -24,7 +24,7 @@ if [ $# -eq 1 ] ; then
 fi
 
 function feder_test_program_compile {
-	if ./jfederc $FEDER_ADDITIONAL -I base -I tests -O "$2" -D tests/build "$1" $FDC_OPTIONS ; then
+	if ./jfederc $FEDER_ADDITIONAL -I base -I tests -O "$2" -D tests/build "$1" "${FDC_OPTIONS[@]}" ; then
 		return 0
 	else
 		return 1
@@ -46,7 +46,7 @@ if ! ./tests/build/ret_true$FEDER_OUTPUT_ENDING ; then
 fi
 
 function feder_test_program_test {
-	if ! timeout 5 $@ > /dev/null ; then
+	if ! timeout 5 "$@" > /dev/null ; then
 		echo "Test \"$1\" failed" 1>&2 
 		HAS_ERROR=1
 	fi
@@ -54,7 +54,7 @@ function feder_test_program_test {
 
 function feder_test {
 	echo "# Test " $1$FEDER_OUTPUT_ENDING
-	if feder_test_program_compile $@ ; then
+	if feder_test_program_compile "$@" ; then
 		feder_test_program_test tests/build/$2
 	else
 		echo "Compiler error"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
 # Copyright (C) 2018 Fionn Langhans <fionn.langhans@gmail.com>
+shopt -s globstar
+
 if ! [ -d "bin" ] ; then mkdir "bin" ; fi
 
-if ! javac -cp src -d bin -encoding UTF-8 -source 8 src/feder/*.java src/feder/utils/*.java src/feder/types/*.java ; then
+if ! javac -cp src -d bin -encoding UTF-8 -source 8 src/feder/**/*.java ; then
 	exit 1
 fi
 
 cd bin
-jar -cfe ./jfederc.jar feder.Feder feder/*.class feder/utils/*.class feder/types/*.class
+jar -cfe ./jfederc.jar feder.Feder feder/**/*.class
 cd ..
 
 if (which doxygen 1>/dev/null) 2>/dev/null ; then


### PR DESCRIPTION
- Enable `sh` option `globstar` and simplify source file globbing.
- Double quote array expansions, otherwise they're like `$*` and break on spaces.
- Assigning an array to a string! Assign as array (or use `*` instead of `@` to concatenate).